### PR TITLE
Add static site built from issues, deployed to GitHub Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish site
+
+on:
+  push:
+    branches: [main]
+  issues:
+    types: [opened, edited, deleted, closed, reopened, labeled, unlabeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node site/build.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -12,9 +12,19 @@ This repository collects articles and notes about product engineering, developer
 
 ## 文章入口
 
-所有文章目前发布在本仓库 Issues：
+静态站点（由 Issues 自动构建）：
+
+[https://jinshuju.github.io/tech-blog/](https://jinshuju.github.io/tech-blog/)
+
+所有文章发布在本仓库 Issues，评论与讨论也在 Issues 进行：
 
 [https://github.com/jinshuju/tech-blog/issues](https://github.com/jinshuju/tech-blog/issues)
+
+### 静态站点如何工作
+
+- 文章即 Issue：`site/config.json` 中 `authors` 名单内成员创建的 open issue 会被发布；close 即下架
+- Issue 的增改、labels 变化、push 到 main 都会触发 [`publish.yml`](./.github/workflows/publish.yml) 重新构建并部署到 GitHub Pages
+- 本地预览：`GITHUB_TOKEN=$(gh auth token) node site/build.mjs`，产物在 `dist/`
 
 ## 推荐主题
 

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -1,0 +1,238 @@
+// Builds a static site from this repo's GitHub issues into dist/.
+// Open issues authored by the users listed in config.json are published;
+// closing an issue takes the post down on the next build.
+import { mkdir, rm, writeFile, readFile, cp } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const outDir = path.join(here, '..', 'dist')
+const config = JSON.parse(await readFile(path.join(here, 'config.json'), 'utf8'))
+
+const token = process.env.GITHUB_TOKEN
+if (!token) {
+  console.error('GITHUB_TOKEN is required (locally: GITHUB_TOKEN=$(gh auth token) node site/build.mjs)')
+  process.exit(1)
+}
+
+const api = async (url, init = {}) => {
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'tech-blog-site-builder',
+      ...init.headers,
+    },
+  })
+  if (!res.ok) throw new Error(`GET ${url} failed: ${res.status} ${await res.text()}`)
+  return res
+}
+
+const fetchPosts = async () => {
+  const issues = []
+  for (let page = 1; ; page++) {
+    const res = await api(`https://api.github.com/repos/${config.repo}/issues?state=open&per_page=100&page=${page}`)
+    const batch = await res.json()
+    if (batch.length === 0) break
+    issues.push(...batch)
+  }
+  return issues
+    .filter((issue) => !issue.pull_request && config.authors.includes(issue.user.login))
+    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+}
+
+const renderMarkdown = async (text) => {
+  const res = await api('https://api.github.com/markdown', {
+    method: 'POST',
+    body: JSON.stringify({ text, mode: 'gfm', context: config.repo }),
+  })
+  return res.text()
+}
+
+const esc = (s) => s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c])
+const langOf = (s) => (/[一-鿿]/.test(s) ? 'zh-CN' : 'en')
+const day = (iso) => iso.slice(0, 10)
+
+const excerpt = (markdown) =>
+  (markdown || '')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#>*`|_~-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 160)
+
+// Cross-references between issues (e.g. 中文版/English version links) should
+// stay on the site instead of jumping back to GitHub.
+const localizeIssueLinks = (html, published) => {
+  const pattern = new RegExp(`href="https://github\\.com/${config.repo.replace('/', '\\/')}/issues/(\\d+)(#[^"]*)?"`, 'g')
+  return html.replace(pattern, (match, number, hash) =>
+    published.has(Number(number)) ? `href="../${number}/${hash ?? ''}"` : match,
+  )
+}
+
+const shell = ({ lang, title, description, canonical, root, body }) => `<!doctype html>
+<html lang="${lang}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(title)}</title>
+<meta name="description" content="${esc(description)}">
+<meta property="og:title" content="${esc(title)}">
+<meta property="og:description" content="${esc(description)}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="${esc(canonical)}">
+<link rel="canonical" href="${esc(canonical)}">
+<link rel="alternate" type="application/atom+xml" title="${esc(config.title)}" href="${root}feed.xml">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>金</text></svg>">
+<link rel="stylesheet" href="${root}style.css">
+</head>
+<body>
+${body}
+<footer class="site-footer">
+<p>© 金数据技术团队 ·
+<a href="https://jinshuju.net">jinshuju.net</a> ·
+<a href="https://github.com/${config.repo}">GitHub</a> ·
+<a href="${root}feed.xml">RSS</a></p>
+</footer>
+</body>
+</html>
+`
+
+const metaLine = (post) => {
+  const labels = post.labels.map((l) => esc(l.name)).join(' / ')
+  return `<time datetime="${day(post.created_at)}">${day(post.created_at)}</time> · ${esc(post.user.login)}${labels ? ` · <span class="labels">${labels}</span>` : ''}`
+}
+
+const indexPage = (posts) => {
+  const byYear = new Map()
+  for (const post of posts) {
+    const year = post.created_at.slice(0, 4)
+    if (!byYear.has(year)) byYear.set(year, [])
+    byYear.get(year).push(post)
+  }
+  let i = 0
+  const groups = [...byYear.entries()]
+    .map(
+      ([year, group]) => `<section class="year">
+<h2 class="year-label">${year}</h2>
+<ol class="entries">
+${group
+  .map(
+    (post) => `<li class="entry" style="--d:${Math.min(i++, 14) * 45}ms">
+<span class="no">№${post.number}</span>
+<div>
+<a class="entry-title" lang="${langOf(post.title)}" href="./posts/${post.number}/">${esc(post.title.trim())}</a>
+<p class="meta">${metaLine(post)}</p>
+</div>
+</li>`,
+  )
+  .join('\n')}
+</ol>
+</section>`,
+    )
+    .join('\n')
+
+  const body = `<header class="masthead">
+<p class="kicker">Engineering Notes · <a href="https://github.com/${config.repo}/issues">GitHub Issues</a> · <a href="./feed.xml">RSS</a></p>
+<h1>${esc(config.title)}</h1>
+<p class="subtitle">${esc(config.subtitle)}</p>
+</header>
+<main>
+${groups}
+</main>`
+
+  return shell({
+    lang: 'zh-CN',
+    title: config.title,
+    description: config.subtitle,
+    canonical: config.url,
+    root: './',
+    body,
+  })
+}
+
+const postPage = (post, contentHtml) => {
+  const title = post.title.trim()
+  const body = `<article>
+<header class="post-header">
+<p class="kicker"><a href="../../">${esc(config.title)}</a> · №${post.number}</p>
+<h1>${esc(title)}</h1>
+<p class="meta">${metaLine(post)}</p>
+</header>
+<div class="markdown-body">
+${contentHtml}
+</div>
+<footer class="post-footer">
+<a href="${esc(post.html_url)}">在 GitHub 上评论 · Comment on GitHub Issue #${post.number} →</a>
+</footer>
+</article>`
+
+  return shell({
+    lang: langOf(title),
+    title: `${title} · ${config.title}`,
+    description: excerpt(post.body),
+    canonical: `${config.url}posts/${post.number}/`,
+    root: '../../',
+    body,
+  })
+}
+
+const atomFeed = (posts, rendered) => {
+  const updated = posts.map((p) => p.updated_at).sort().at(-1) ?? new Date(0).toISOString()
+  const entries = posts
+    .slice(0, 20)
+    .map((post) => {
+      const url = `${config.url}posts/${post.number}/`
+      return `<entry>
+<title>${esc(post.title.trim())}</title>
+<link href="${esc(url)}"/>
+<id>${esc(url)}</id>
+<published>${post.created_at}</published>
+<updated>${post.updated_at}</updated>
+<author><name>${esc(post.user.login)}</name></author>
+${post.labels.map((l) => `<category term="${esc(l.name)}"/>`).join('\n')}
+<content type="html">${esc(rendered.get(post.number))}</content>
+</entry>`
+    })
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+<title>${esc(config.title)}</title>
+<subtitle>${esc(config.subtitle)}</subtitle>
+<link href="${esc(config.url)}"/>
+<link rel="self" href="${esc(config.url)}feed.xml"/>
+<id>${esc(config.url)}</id>
+<updated>${updated}</updated>
+${entries}
+</feed>
+`
+}
+
+const posts = await fetchPosts()
+console.log(`Publishing ${posts.length} posts`)
+
+const published = new Set(posts.map((p) => p.number))
+// Feed entries keep absolute GitHub links; post pages get site-relative ones.
+const rendered = new Map()
+for (const post of posts) {
+  rendered.set(post.number, await renderMarkdown(post.body || ''))
+  console.log(`  rendered #${post.number} ${post.title.trim()}`)
+}
+
+await rm(outDir, { recursive: true, force: true })
+await mkdir(outDir, { recursive: true })
+await cp(path.join(here, 'style.css'), path.join(outDir, 'style.css'))
+await writeFile(path.join(outDir, 'index.html'), indexPage(posts))
+await writeFile(path.join(outDir, 'feed.xml'), atomFeed(posts, rendered))
+for (const post of posts) {
+  const dir = path.join(outDir, 'posts', String(post.number))
+  await mkdir(dir, { recursive: true })
+  await writeFile(path.join(dir, 'index.html'), postPage(post, localizeIssueLinks(rendered.get(post.number), published)))
+}
+console.log(`Done → ${outDir}`)

--- a/site/config.json
+++ b/site/config.json
@@ -1,0 +1,15 @@
+{
+  "title": "金数据技术博客",
+  "subtitle": "Jinshuju Tech Blog · Engineering notes from the Jinshuju team",
+  "repo": "jinshuju/tech-blog",
+  "url": "https://jinshuju.github.io/tech-blog/",
+  "authors": [
+    "flanker",
+    "silverWolf818",
+    "iwfan",
+    "plrthink",
+    "xianguoGou",
+    "emotionl",
+    "BigBossTang"
+  ]
+}

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,297 @@
+:root {
+  --paper: #faf8f3;
+  --ink: #211e18;
+  --ink-soft: #6f6858;
+  --hairline: #e2dccd;
+  --gold: #96781d;
+  --gold-deep: #7a6012;
+  --code-bg: #f1ede2;
+  --code-ink: #3a352b;
+  --tok-comment: #8d8574;
+  --tok-keyword: #9d4239;
+  --tok-string: #43653f;
+  --tok-const: #8a5a00;
+  --tok-entity: #6b539b;
+  --tok-tag: #38635e;
+  --serif: "Georgia", "Times New Roman", "Songti SC", "Noto Serif SC", "SimSun", serif;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #1b1914;
+    --ink: #e9e4d8;
+    --ink-soft: #a29a88;
+    --hairline: #37332a;
+    --gold: #d3ac4d;
+    --gold-deep: #e5c06f;
+    --code-bg: #24211a;
+    --code-ink: #d8d2c2;
+    --tok-comment: #837b69;
+    --tok-keyword: #e08a7d;
+    --tok-string: #9ec08b;
+    --tok-const: #d9b35c;
+    --tok-entity: #b5a3e8;
+    --tok-tag: #82c0b7;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.75;
+}
+
+body > * {
+  max-width: 44rem;
+  margin-inline: auto;
+  padding-inline: 1.25rem;
+}
+
+a { color: inherit; text-decoration: underline; text-decoration-color: var(--gold); text-underline-offset: 3px; }
+a:hover { color: var(--gold-deep); }
+
+.kicker {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin: 0 0 0.75rem;
+}
+.kicker a { color: inherit; text-decoration: none; }
+.kicker a:hover { text-decoration: underline; }
+
+.meta {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--ink-soft);
+  margin: 0.3rem 0 0;
+}
+
+/* ---------- masthead / index ---------- */
+
+.masthead {
+  border-top: 4px double var(--ink);
+  border-bottom: 1px solid var(--hairline);
+  padding-top: 2.5rem;
+  padding-bottom: 1.75rem;
+  margin-top: 2rem;
+}
+
+.masthead h1 {
+  font-family: var(--serif);
+  font-size: clamp(2.1rem, 6vw, 3.1rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin: 0;
+}
+
+.masthead .subtitle {
+  color: var(--ink-soft);
+  margin: 0.5rem 0 0;
+  font-size: 0.95rem;
+}
+
+.year { margin-top: 2.5rem; }
+
+.year-label {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.2em;
+  color: var(--ink-soft);
+  border-bottom: 1px solid var(--hairline);
+  padding-bottom: 0.4rem;
+  margin: 0 0 0.5rem;
+}
+
+.entries { list-style: none; margin: 0; padding: 0; }
+
+.entry {
+  display: grid;
+  grid-template-columns: 3.6rem 1fr;
+  gap: 0.9rem;
+  padding: 1.05rem 0;
+}
+.entry + .entry { border-top: 1px solid var(--hairline); }
+
+.no {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--gold);
+  padding-top: 0.35rem;
+  white-space: nowrap;
+}
+
+.entry-title {
+  font-family: var(--serif);
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.45;
+  text-decoration: none;
+}
+.entry-title:hover {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--gold);
+  text-decoration-thickness: 2px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .masthead, .entry {
+    animation: rise 0.45s ease both;
+    animation-delay: var(--d, 0ms);
+  }
+  @keyframes rise {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: none; }
+  }
+}
+
+/* ---------- post page ---------- */
+
+article { margin-top: 2rem; }
+
+.post-header {
+  border-top: 4px double var(--ink);
+  border-bottom: 1px solid var(--hairline);
+  padding-top: 2.5rem;
+  padding-bottom: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.post-header h1 {
+  font-family: var(--serif);
+  font-size: clamp(1.6rem, 5vw, 2.3rem);
+  line-height: 1.35;
+  margin: 0;
+}
+
+.post-footer {
+  border-top: 1px solid var(--hairline);
+  margin-top: 3rem;
+  padding: 1.5rem 0 0.5rem;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+}
+
+.site-footer {
+  border-top: 1px solid var(--hairline);
+  margin-top: 3.5rem;
+  padding-top: 1.25rem;
+  padding-bottom: 2.5rem;
+  font-size: 0.8rem;
+  color: var(--ink-soft);
+}
+
+/* ---------- markdown body (GitHub-rendered HTML) ---------- */
+
+.markdown-body { overflow-wrap: break-word; }
+
+.markdown-body h1, .markdown-body h2, .markdown-body h3,
+.markdown-body h4, .markdown-body h5, .markdown-body h6 {
+  font-family: var(--serif);
+  line-height: 1.4;
+  margin: 2.2em 0 0.7em;
+}
+.markdown-body h1 { font-size: 1.6rem; }
+.markdown-body h2 { font-size: 1.4rem; border-bottom: 1px solid var(--hairline); padding-bottom: 0.3em; }
+.markdown-body h3 { font-size: 1.15rem; }
+
+.markdown-body p { margin: 0 0 1.1em; }
+
+.markdown-body img {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--hairline);
+  border-radius: 4px;
+}
+
+.markdown-body blockquote {
+  margin: 1.2em 0;
+  padding: 0.1em 1.2em;
+  border-left: 3px solid var(--gold);
+  color: var(--ink-soft);
+}
+
+.markdown-body hr { border: 0; border-top: 1px solid var(--hairline); margin: 2.5em 0; }
+
+.markdown-body ul, .markdown-body ol { padding-left: 1.6em; margin: 0 0 1.1em; }
+.markdown-body li + li { margin-top: 0.25em; }
+.markdown-body .task-list-item { list-style: none; margin-left: -1.4em; }
+
+.markdown-body table {
+  border-collapse: collapse;
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
+  margin: 0 0 1.2em;
+  font-size: 0.92em;
+}
+.markdown-body th, .markdown-body td {
+  border: 1px solid var(--hairline);
+  padding: 0.45em 0.8em;
+}
+.markdown-body th { background: var(--code-bg); font-family: var(--mono); font-size: 0.85em; }
+
+.markdown-body code {
+  font-family: var(--mono);
+  font-size: 0.86em;
+  background: var(--code-bg);
+  border-radius: 4px;
+  padding: 0.15em 0.35em;
+}
+
+.markdown-body pre {
+  background: var(--code-bg);
+  color: var(--code-ink);
+  border-radius: 6px;
+  padding: 1em 1.2em;
+  overflow-x: auto;
+  line-height: 1.6;
+  margin: 0 0 1.2em;
+}
+.markdown-body pre code { background: none; padding: 0; font-size: 0.86rem; }
+.markdown-body .highlight pre { margin: 0 0 1.2em; }
+
+.markdown-body sup a { text-decoration: none; font-family: var(--mono); font-size: 0.8em; }
+.markdown-body details { margin: 0 0 1.1em; }
+.markdown-body summary { cursor: pointer; }
+
+.markdown-body .markdown-alert {
+  border-left: 3px solid var(--gold);
+  padding: 0.1em 1.2em;
+  margin: 1.2em 0;
+}
+.markdown-body .markdown-alert-title {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--gold);
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+}
+.markdown-body .markdown-alert-title .octicon { fill: currentColor; }
+
+/* GitHub (Linguist) syntax token classes */
+.pl-c, .pl-c span { color: var(--tok-comment); font-style: italic; }
+.pl-k, .pl-kos { color: var(--tok-keyword); }
+.pl-s, .pl-pds, .pl-sr { color: var(--tok-string); }
+.pl-c1, .pl-mi, .pl-mb { color: var(--tok-const); }
+.pl-en { color: var(--tok-entity); }
+.pl-e { color: var(--tok-entity); }
+.pl-ent { color: var(--tok-tag); }
+.pl-smi, .pl-v { color: var(--code-ink); }
+.pl-mh, .pl-mh .pl-en, .pl-ms { color: var(--tok-entity); font-weight: 600; }
+.pl-md { color: var(--tok-keyword); background: transparent; }
+.pl-mi1 { color: var(--tok-string); background: transparent; }


### PR DESCRIPTION
## What

A static site generated from this repo's issues, published to **https://jinshuju.github.io/tech-blog/** via GitHub Pages.

- `site/build.mjs` — zero-dependency Node script: fetches open issues, renders each body with GitHub's `/markdown` API (full GFM fidelity: tables, syntax highlighting, alerts), and writes `dist/` (index grouped by year, one page per post, Atom feed).
- `.github/workflows/publish.yml` — rebuilds and deploys on **issue changes** (opened/edited/closed/reopened/labeled/deleted), on **push to main**, and on manual dispatch.
- `site/config.json` — site metadata plus the **author allowlist**: since this is a public repo and `author_association` is unreliable (several past authors now show `NONE`), only open issues created by listed authors are published. Closing an issue takes the post down.

## Details

- Issue-to-issue links (中文版 / English Version) are rewritten to point at the site; the Atom feed keeps absolute GitHub links.
- Light/dark themes follow `prefers-color-scheme`; no external fonts or JS.
- GitHub Pages is already enabled for this repo with `build_type: workflow` — merging this PR triggers the first deploy.
- Local preview: `GITHUB_TOKEN=$(gh auth token) node site/build.mjs` → `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvcUXqRTwuVAK1rnUMAB1p