### PR TITLE
Point site URL at tech.jinshuju.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository collects articles and notes about product engineering, developer
 
 静态站点（由 Issues 自动构建）：
 
-[https://jinshuju.github.io/tech-blog/](https://jinshuju.github.io/tech-blog/)
+[https://tech.jinshuju.net/](https://tech.jinshuju.net/)
 
 所有文章发布在本仓库 Issues，评论与讨论也在 Issues 进行：
 

--- a/site/config.json
+++ b/site/config.json
@@ -2,7 +2,7 @@
   "title": "金数据技术博客",
   "subtitle": "Jinshuju Tech Blog · Engineering notes from the Jinshuju team",
   "repo": "jinshuju/tech-blog",
-  "url": "https://jinshuju.github.io/tech-blog/",
+  "url": "https://tech.jinshuju.net/",
   "authors": [
     "flanker",
     "silverWolf818",


### PR DESCRIPTION
DNS CNAME (tech.jinshuju.net → jinshuju.github.io) is live and the custom domain is bound in Pages settings. This updates the canonical/feed base URL in `site/config.json` and the README link. All in-page links are relative, so moving from the /tech-blog/ subpath to the domain root needs nothing else; the old jinshuju.github.io/tech-blog URL 301s automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvcUXqRTwuVAK1rnUMAB1p